### PR TITLE
Basic File Loader + templates for a bunch of objects

### DIFF
--- a/BalaRTo.lua
+++ b/BalaRTo.lua
@@ -824,3 +824,52 @@ SMODS.DeckSkin {
 		},
 	},
 }
+
+local paths = {
+    atlases = "content/atlas",
+    blinds = "content/blind",
+    decks = "content/deck",
+    enhancements = "content/enhancement",
+    jokers = "content/joker",
+    planets = "content/planet",
+    spectrals = "content/spectral",
+    tarots = "content/tarot",
+    vouchers = "content/voucher",
+}
+
+--- Loads and runs a file containing lua code at the specified path.
+---@param path string The path to the file from the root of the current mod.
+local function exec_file(path)
+    local file, msg = SMODS.load_file(path)
+
+    if msg then
+        error(msg)
+    end
+    file()
+end
+
+local mod_path = SMODS.current_mod.path
+
+-- Basic loader for mod objects
+-- Only loads lua files directly inside each directory specified in `paths`. Sub-directories are ignored.
+for type, path in pairs(paths) do
+    local files = NFS.getDirectoryItems(SMODS.current_mod.path .. path)
+    local loaded = 0
+
+    for _, file in ipairs(files) do
+        local full_path = path .."/"..file
+
+        local info = NFS.getInfo(mod_path .. full_path)
+
+        -- There shouldn't be any sub-directories or non-lua files, but let's ignore them anyway
+        if info and info.type == "file" and file:sub(-3) == "lua" or file == "template.lua" then
+            exec_file(full_path)
+            loaded = loaded + 1
+        end
+    end
+
+    -- We can check that files are being found and loaded properly with these logs
+    if loaded > 0 then
+        sendInfoMessage("Successfully loaded "..loaded.." "..tostring(type))
+    end
+end

--- a/content/atlas/template.lua
+++ b/content/atlas/template.lua
@@ -1,0 +1,20 @@
+-- Template file for a texture atlas.
+-- Sprites for cards and other objects must be fetched from an atlas. 
+-- Atlases can contain any amount of textures of the same size and there must be a 1x and 2x version.
+
+SMODS.Atlas {
+    -- Internal name of the atlas
+    key = 'atlas_name',
+    -- Width of one sprite on the atlas (excluding padding)
+    px = 69, -- Example: joker sprite width
+    -- Height of one sprite on the atlas (excluding padding)
+    py = 93, -- Example: joker sprite height
+    -- Path to the atlas inside of `assets/1x`, `assets/2x`
+    path = 'atlas_path.png',
+    -- The type of atlas, can be either `ASSET_ATLAS`, `ANIMATION_ATLAS`, or `ASSET_IMAGES`
+    atlas_table = 'ASSET_ATLAS',
+    -- The number of frames for each sprite if the atlas table is `ANIMATION_ATLAS`
+    -- frames = 1
+    -- Set to true if textures are experiencing artifacting
+    disable_mipmap = false,
+}

--- a/content/blind/template.lua
+++ b/content/blind/template.lua
@@ -1,0 +1,98 @@
+-- Template file for a custom blind
+
+SMODS.Blind {
+    -- Internal name of the blind
+    key = 'blind_key',
+    -- Localization
+    loc_txt = {
+        -- Name of the blind
+        name = 'blind_name',
+        -- Description of the blind
+        text = {
+            'Each entry in this table',
+            'Is a new line'
+        }
+    },
+    -- The name of the atlas this blind's animation is on
+    atlas = 'blind_chips', -- Atlas must be animated
+    -- Position of the blind sprite in the atlas above
+    pos = {
+        x = 0, -- Value is ignored
+        y = 0, -- The animation row to use for this blind chip
+    },
+    -- Reward money (usually $5)
+    dollars = 5,
+    -- Required chips multiplier for this boss blind (usually 2x)
+    mult = 2,
+    boss = {
+        -- Minimum ante this boss blind can spawn on
+        min = 1,
+        -- Marks this boss as a showdown blind (Appears on winning ante and multiples only)
+        showdown = false,
+    },
+    -- Background colour while fighting this boss
+    boss_colour = HEX('FFFFFF'), -- Pure white
+    -- Vanilla debuff effects (Look at Steamodded wiki for this one https://github.com/Steamodded/smods/wiki/SMODS.Blind)
+    debuff = {},
+    -- Variables for the blind description in the collection.
+    vars = {},
+
+    -- Blind Functions
+    -- Remove any functions that you do not intend to use!
+
+    -- Effects that activate when this blind is selected
+    set_blind = function (self)
+        
+    end,
+    -- Revert effects when the blind is disabled
+    disable = function (self)
+        
+    end,
+    -- Revert effects when the blind is defeated
+    defeat = function (self)
+        
+    end,
+    -- Effects that activate a card is drawn to hand
+    drawn_to_hand = function (self)
+        
+    end,
+    -- Effects that activate when a hand is played
+    press_play = function (self)
+        
+    end,
+    -- Determines whether a card should be debuffed by this blind
+    recalc_debuff = function (self, card, from_blind)
+        -- return true to debuff card
+    end,
+    -- Determines whether a hand should be debuffed by this blind
+    debuff_hand = function (self, cards, hand, handname, check)
+        -- return true to debuff hand
+    end,
+    -- Determines whether a card should remain face down when drawn
+    stay_flipped = function (self, area, card)
+        -- return true to remain flipped
+    end,
+    -- Modifies the base score of played hands
+    modify_hand = function (self, cards, poker_hands, text, mult, hand_chips)
+        -- return modified_mult (new hand mult), modified_hand_chips (new hand chips), modified (true if either value has changed)
+    end,
+    -- Modifies the warning text displayed for debuffed hands
+    get_loc_debuff_text = function (self)
+        -- return "text" for new debuff warning
+    end,
+    -- Localisation variables 
+    loc_vars = function (self)
+        
+    end,
+    -- Localisation variables for the collection
+    collection_loc_vars = function (self)
+        
+    end,
+    -- Custom logic that can be used for determining if this blind can appear.
+    -- Disables `boss.min` from taking effect.
+    in_pool = function (self)
+        -- return true if this blind can appear right now
+        -- return false if it can not appear right now
+    end,
+
+}

--- a/content/deck/template.lua
+++ b/content/deck/template.lua
@@ -1,0 +1,52 @@
+-- Template for custom decks.
+-- Note that there are two types of deck - `SMODS.Back` and `SMODS.Challenge`.
+-- This only includes Back because i am lazy and challenge is really complex, sorry...
+-- Read about challenge decks on steamodded wiki: https://github.com/Steamodded/smods/wiki/SMODS.Challenge
+
+SMODS.Back {
+    -- Internal name of this deck
+    key = 'deck_key',
+    -- Localization
+    loc_txt = {
+        -- Name of this deck
+        name = 'Deck Name',
+        -- Description of this deck
+        text = {
+            'Deck description',
+            'New entry = new line',
+        }
+    },
+    -- The name of the atlas this deck sprite is on
+    atlas = 'decks',
+    -- The position of the sprite on the atlas.
+    pos = {
+        x = 0,
+        y = 0,
+    },
+    -- Whether this deck is unlocked by default
+    unlocked = true,
+    -- Calculate function for this deck
+    calculate = function (self, back, context)
+        
+    end,
+    -- Apply modifiers at the start of the run
+    apply = function (self, back)
+        
+    end,
+    -- Determine whether specific cards are able to spawn
+    in_pool = function (self, args)
+        -- return true to allow a card to spawn
+    end,
+    -- Configure when this deck is unlocked if not unlocked by default
+    check_for_unlock = function (self, args)
+        -- return true to unlock deck
+    end,
+
+    -- Localisation: https://github.com/Steamodded/smods/wiki/Localization#Localization-functions
+    loc_vars = function (self, info_queue, card)
+        
+    end,
+    locked_loc_vars = function (self, info_queue, card)
+        
+    end,
+}

--- a/content/enhancement/template.lua
+++ b/content/enhancement/template.lua
@@ -1,0 +1,127 @@
+-- Templates for custom card enhancements. Included are Enhancement, Edition. 
+
+SMODS.Enhancement {
+    -- Internal name
+    key = 'object_key',
+    -- Localization
+    loc_txt = {
+        -- Name of this enhancement
+        name = 'Enhancement Name',
+        -- Description of this enhancement
+        text = {
+            'Description',
+            'New entry = new line',
+        }
+    },
+    -- The name of the atlas this object's sprite is on
+    atlas = 'atlas_name',
+    -- The position of the sprite on the atlas.
+    pos = {
+        x = 0,
+        y = 0,
+    },
+    -- Types of modifier this enhancement can give, unconditionally
+    config = {
+        bonus = 0,
+        x_chips = 0,
+        mult = 0,
+        x_mult = 0,
+        h_chips = 0,
+        h_x_chips = 0,
+        h_mult = 0,
+        h_x_mult = 0,
+        p_dollars = 0,
+        h_dollars = 0,
+        -- Set custom variables in here
+        extra = {
+
+        }
+    },
+    -- Remove the original card sprite and chips (stone card type effect)
+    replace_base_card = false,
+    -- Nullifies card rank if true (Stone Card)
+    no_rank = false,
+    -- Nullfies card suit if true (Stone Card)
+    no_suit = false,
+    -- Stops Grim, Familiar, and Incantation generating this enhancement if true
+    overrides_base_rank = false,
+    -- Allows card to pass as all suits if true (Wild Card)
+    any_suit = false,
+    -- This card always scores when played if true
+    always_scores = false,
+    -- Weight of this enhancement in rolling. Defaults to 5. Higher numbers = more common
+    weight = 5,
+
+    calculate = function(self, card, context)
+
+    end,
+
+    -- Other Functions: https://github.com/Steamodded/smods/wiki/SMODS.Enhancement#api-methods
+
+    -- Localisation: https://github.com/Steamodded/smods/wiki/Localization#Localization-functions
+    loc_vars = function (self, info_queue, card)
+        
+    end,
+    locked_loc_vars = function (self, info_queue, card)
+        
+    end,
+}
+
+SMODS.Edition {
+    -- Internal name
+    key = 'object_key',
+    -- Localization
+    loc_txt = {
+        -- Name of this edition
+        name = 'Edition Name',
+        -- Description of this edition
+        text = {
+            'Description',
+            'New entry = new line',
+        }
+    },
+    -- key of the shader to use or `false` for no shader.
+    shader = 'shader_key',
+    -- Edition Only: The atlas points to the card sprite used behind this in the collection.
+    -- The name of the atlas this sprite is on.
+    atlas = 'atlas_name',
+    -- The position of the sprite on the atlas.
+    pos = {
+        x = 0,
+        y = 0,
+    },
+    -- Types of modifier this edition can give, unconditionally
+    config = {
+        chips = 0,
+        mult = 0,
+        x_mult = 0,
+        p_dollars = 0,
+        card_limit = 0,
+        -- Set custom variables in here
+        extra = {
+
+        }
+    },
+    -- Whether the edition can appear in the shop
+    in_shop = false,
+    -- Weight of the edition
+    weight = 0,
+    -- Extra cost of cards in the shop when they have this edition
+    extra_cost = 0,
+    -- Whether the shader should apply to floating sprites or not
+    apply_to_float = false,
+    -- A custom badge colour for the edition
+    badge_colour = G.C.DARK_EDITION,
+    -- The sound to play when edition is applied
+    sound = {
+        sound = "foil1",
+        per = 1.2,
+        vol = 0.4,
+    },
+    --Disables the shadow drawn beneath this card
+    disable_shadow = false,
+    -- Set to true if edition shader modifies transparency or card shape
+    disable_base_shader = false,
+
+    -- Functions: https://github.com/Steamodded/smods/wiki/SMODS.Edition#api-methods
+}

--- a/content/joker/template.lua
+++ b/content/joker/template.lua
@@ -1,0 +1,50 @@
+-- Template file for a custom Joker
+
+SMODS.Joker {
+    -- Internal name
+    key = 'object_key',
+    -- Localization
+    loc_txt = {
+        -- Name of this Joker
+        name = 'Joker Name',
+        -- Description of this Joker
+        text = {
+            'Description',
+            'New entry = new line',
+        }
+    },
+    -- The name of the atlas this object's sprite is on
+    atlas = 'atlas_name',
+    -- The position of the sprite on the atlas.
+    pos = {
+        x = 0,
+        y = 0,
+    },
+    -- Initial object values
+    config = {
+        -- Set custom variables in here
+        extra = {
+
+        }
+    },
+    -- Rarity of the Joker, 1 = Common up to 4 = Legendary.
+    rarity = 1,
+    -- Cost of this Joker
+    cost = 3,
+    -- Cosmetic only. Blueprint compatibility needs it's own code (context.blueprint)
+    blueprint_compat = false,
+    -- Can have eternal stickers
+    eternal_compat = true,
+    -- Can have perishable stickers
+    perishable_compat = true,
+
+    -- Functions: https://github.com/Steamodded/smods/wiki/SMODS.Joker#api-methods
+
+    -- Localisation: https://github.com/Steamodded/smods/wiki/Localization#Localization-functions
+    loc_vars = function (self, info_queue, card)
+        
+    end,
+    locked_loc_vars = function (self, info_queue, card)
+        
+    end,
+}

--- a/content/planet/template.lua
+++ b/content/planet/template.lua
@@ -1,0 +1,59 @@
+-- Planet Template file
+
+SMODS.Consumable {
+    -- Internal name
+    key = 'object_key',
+    -- Localization
+    loc_txt = {
+        -- Name of this consumable
+        name = 'Consumable Name',
+        -- Description of this consumable
+        text = {
+            'Description',
+            'New entry = new line',
+        }
+    },
+    -- The name of the atlas this object's sprite is on
+    atlas = 'atlas_name',
+    -- The position of the sprite on the atlas.
+    pos = {
+        x = 0,
+        y = 0,
+    },
+    set = 'Planet',
+    -- Initial object values
+    config = {
+        -- Set custom variables in here
+        extra = {
+
+        }
+    },
+    -- Cost of this card in the shop
+    cost = 3,
+    -- Legenadry consumables like The Soul are hidden
+    hidden = false,
+    -- Legendary variables
+    --soul_set = 'Spectral',
+    --soul_rate = 0.003,
+    --can_repeat_soul = false,
+
+    -- Determines whether the consumable can currently be played. 
+    can_use = function (self, card)
+        -- return true if the consumable can be played
+    end,
+
+    -- Runs when the consumable is used
+    use = function (card, area, copier)
+        
+    end,
+
+    -- Other Functions: https://github.com/Steamodded/smods/wiki/SMODS.Joker#api-methods
+
+    -- Localisation: https://github.com/Steamodded/smods/wiki/Localization#Localization-functions
+    loc_vars = function (self, info_queue, card)
+        
+    end,
+    locked_loc_vars = function (self, info_queue, card)
+        
+    end,
+}

--- a/content/spectral/template.lua
+++ b/content/spectral/template.lua
@@ -1,0 +1,59 @@
+-- Spectral Template file
+
+SMODS.Consumable {
+    -- Internal name
+    key = 'object_key',
+    -- Localization
+    loc_txt = {
+        -- Name of this consumable
+        name = 'Consumable Name',
+        -- Description of this consumable
+        text = {
+            'Description',
+            'New entry = new line',
+        }
+    },
+    -- The name of the atlas this object's sprite is on
+    atlas = 'atlas_name',
+    -- The position of the sprite on the atlas.
+    pos = {
+        x = 0,
+        y = 0,
+    },
+    set = 'Spectral',
+    -- Initial object values
+    config = {
+        -- Set custom variables in here
+        extra = {
+
+        }
+    },
+    -- Cost of this card in the shop
+    cost = 3,
+    -- Legenadry consumables like The Soul are hidden
+    hidden = false,
+    -- Legendary variables
+    --soul_set = 'Spectral',
+    --soul_rate = 0.003,
+    --can_repeat_soul = false,
+
+    -- Determines whether the consumable can currently be played. 
+    can_use = function (self, card)
+        -- return true if the consumable can be played
+    end,
+
+    -- Runs when the consumable is used
+    use = function (card, area, copier)
+        
+    end,
+
+    -- Other Functions: https://github.com/Steamodded/smods/wiki/SMODS.Joker#api-methods
+
+    -- Localisation: https://github.com/Steamodded/smods/wiki/Localization#Localization-functions
+    loc_vars = function (self, info_queue, card)
+        
+    end,
+    locked_loc_vars = function (self, info_queue, card)
+        
+    end,
+}

--- a/content/tarot/template.lua
+++ b/content/tarot/template.lua
@@ -1,0 +1,59 @@
+-- Tarot Template file
+
+SMODS.Consumable {
+    -- Internal name
+    key = 'object_key',
+    -- Localization
+    loc_txt = {
+        -- Name of this consumable
+        name = 'Consumable Name',
+        -- Description of this consumable
+        text = {
+            'Description',
+            'New entry = new line',
+        }
+    },
+    -- The name of the atlas this object's sprite is on
+    atlas = 'atlas_name',
+    -- The position of the sprite on the atlas.
+    pos = {
+        x = 0,
+        y = 0,
+    },
+    set = 'Tarot',
+    -- Initial object values
+    config = {
+        -- Set custom variables in here
+        extra = {
+
+        }
+    },
+    -- Cost of this card in the shop
+    cost = 3,
+    -- Legenadry consumables like The Soul are hidden
+    hidden = false,
+    -- Legendary variables
+    --soul_set = 'Spectral',
+    --soul_rate = 0.003,
+    --can_repeat_soul = false,
+
+    -- Determines whether the consumable can currently be played. 
+    can_use = function (self, card)
+        -- return true if the consumable can be played
+    end,
+
+    -- Runs when the consumable is used
+    use = function (card, area, copier)
+        
+    end,
+
+    -- Other Functions: https://github.com/Steamodded/smods/wiki/SMODS.Joker#api-methods
+
+    -- Localisation: https://github.com/Steamodded/smods/wiki/Localization#Localization-functions
+    loc_vars = function (self, info_queue, card)
+        
+    end,
+    locked_loc_vars = function (self, info_queue, card)
+        
+    end,
+}

--- a/content/voucher/template.lua
+++ b/content/voucher/template.lua
@@ -1,0 +1,46 @@
+-- Voucher template file
+
+SMODS.Voucher {
+    -- Internal name
+    key = 'object_key',
+    -- Localization
+    loc_txt = {
+        -- Name of this voucher
+        name = 'Voucher Name',
+        -- Description of this voucher
+        text = {
+            'Description',
+            'New entry = new line',
+        }
+    },
+    -- The name of the atlas this object's sprite is on
+    atlas = 'atlas_name',
+    -- The position of the sprite on the atlas.
+    pos = {
+        x = 0,
+        y = 0,
+    },
+    -- Cost of this voucher
+    cost = 10,
+    -- All the prerequisite vouchers that must be bought before this one.
+    -- Listed by their full key.
+    requires = {
+        'BalaRTo_voucher', -- for other vouchers in this mod 
+        'v_voucher', -- For vanilla vouchers
+    },
+
+    -- Defines what heppens when the voucher is redeemed
+    redeem = function (self, card)
+
+    end,
+
+    -- Other Functions: https://github.com/Steamodded/smods/wiki/SMODS.Voucher#api-methods
+
+    -- Localisation: https://github.com/Steamodded/smods/wiki/Localization#Localization-functions
+    loc_vars = function (self, info_queue, card)
+
+    end,
+    locked_loc_vars = function (self, info_queue, card)
+
+    end,
+}


### PR DESCRIPTION
This adds a (hopefully working) loader for additional files in folders to make it easier to organise custom content - these are all in the `content` folder and the folders it loads right now should be `atlas`, `blind`, `deck`, `enhancement`, `joker`, `planet`, `spectral`, `tarot`, `voucher`.
Also added template files into each one of these - the loader should ignore them specifically, but if it's working then every folder loaded should log how many files it loaded from each. Hopefully.